### PR TITLE
Update c9.io.yaml

### DIFF
--- a/profiles/c9.io.yaml
+++ b/profiles/c9.io.yaml
@@ -1,10 +1,27 @@
 name: Cloud9 IDE
 password:
+  value:
+    notes:
+    - en: >
+        Password form rejects passwords that are "not strong enough"
+        based on an arbitrary character-class-based formula, unrelated
+        to the displayed "strength-o-meter" (which is just a progress
+        bar of the password's length up to 24 characters).
   reset:
-    url: https://c9.io/#resetPasswordForm
+    url: https://c9.io/auth/password/reset
     flow:
       request:
         accepts: username email
+      response:
+        email:
+          sender: support@c9.io
+          body: firstname url
+        expire: 15m
   change:
-    url: https://c9.io/dashboard.html
-    reauth: no
+    url: https://c9.io/account/settings
+registration:
+  url: https://c9.io/signup
+login:
+  url: https://c9.io/login
+reviewed:
+  date: 2017-02-07T22:18:14.236Z

--- a/profiles/c9.io.yaml
+++ b/profiles/c9.io.yaml
@@ -19,6 +19,10 @@ password:
         expire: 15m
   change:
     url: https://c9.io/account/settings
+    notes:
+    - en: >
+        The user settings page features a "Request password" button
+        that initiates a password reset request.
 registration:
   url: https://c9.io/signup
 login:


### PR DESCRIPTION
Other observations:

- Login accepts (#74) either username or email address.

I didn't test password reset, due to the *asinine* password "strength" requirement: I would guess it's probably at least `sessions.own: stay` (since reset is designed to work for *changing* a password), though I'd need to check it to confirm.