### PR TITLE
Update paypal.com.yaml

### DIFF
--- a/profiles/paypal.com.yaml
+++ b/profiles/paypal.com.yaml
@@ -5,16 +5,29 @@ password:
       min: 8
       max: 20
   contents:
+    required:
+    - atleast: 1
+      classes:
+      - digits
+      - symbols
     blacklist:
       classes:
       - spaces
       - nonprinting
   reset:
-    url: https://www.paypal.com/us/cgi-bin/webscr?cmd=_account-recovery
+    url: https://www.paypal.com/webapps/accountrecovery/passwordrecovery
     flow:
       request:
         accepts: email
-        captcha: yes
+        captcha: alphanumeric
+      response:
+        email:
+          sender: service@paypal.com
+          body: token
   change:
     url: https://www.paypal.com/us/cgi-bin/webscr?cmd=_profile-password-start
     reauth: password
+    sessions:
+      own: deauth
+reviewed:
+  date: 2017-02-08T04:42:35.421Z


### PR DESCRIPTION
Some observations not included here:

- My own "reset password" page has a different URL than what is listed here (https://www.paypal.com/businessprofile/settings/password). Non-business users appear to have a different URL as well (https://www.paypal.com/myaccount/settings/password/edit/). These two URLs are incompatible; as such, I'm keeping the previous value, which is still compatible for both.
- The captcha for resetting uses mixed case, but doesn't appear to be case-sensitive (#153).
- Resetting a password also supports SMS response (from 729725, natch) with a six-digit code (like the email) that expires 5 minutes from sending, and a phone call (don't know from what number, the option expired after requesting an email and a text).