### PR TITLE
Update and rename WILDCARD.residentportal.com.yaml

### DIFF
--- a/profiles/WILDCARD.residentportal.com.yaml
+++ b/profiles/WILDCARD.residentportal.com.yaml
@@ -1,0 +1,42 @@
+name: ResidentPortal
+password:
+  value:
+    length:
+      min: 6
+  contents:
+    required:
+    - atleast: 2
+      classes:
+      - uppers
+      - lowers
+      - numbers
+  reset:
+    url: https://*.residentportal.com/resident_portal/?module=forgot_password&action=forgot_password
+    flow:
+      request:
+        accepts: email
+      response:
+        email:
+          body: link
+        expire: 72h
+      submit:
+        destination:
+          page: stub
+        sessions:
+          own: unchanged
+        expire: unchanged
+  change: 
+    url: https://*.residentportal.com/resident_portal/?module=customer&action=view_customer#ChangePassword
+login:
+  url: https://*.residentportal.com/resident_portal/?module=authentication&action=view_login
+registration:
+  url: https://*.residentportal.com/resident_portal/?module=authentication&action=view_login
+thirdparty:
+  auth:
+    providers:
+    - facebook.com # although I've yet to see this actually work
+distinguish:
+  subdomains:
+    level: 3
+reviewed:
+  date: 2017-02-09T10:09:17.908Z

--- a/profiles/skyeatbelltown.residentportal.com.yaml
+++ b/profiles/skyeatbelltown.residentportal.com.yaml
@@ -1,6 +1,0 @@
-name: Skye at Belltown
-password:
-  reset:
-    url: https://skyeatbelltown.residentportal.com/resident_portal/?module=forgot_password
-  change: 
-    url: https://skyeatbelltown.residentportal.com/resident_portal/?module=customer#ChangePassword


### PR DESCRIPTION
Some observations not in this profile:

- The site can be demoed if you aren't a resident of a ResidentPortal property via https://demo.residentportal.com/
- Terms and Conditions (#22) are available at https://demo.residentportal.com/resident_portal/?module=enroll&action=view_terms_and_conditions
- `password.reset.flow.response.email.sender` appears to be installation-specific (mine was "info@skyebelltown.com", for instance), and as such is not profiled here.
- The stub page after resetting a password has a "log in" link. Apparently I still haven't added a field to describe this (wasn't there going to be something like `password.reset.flow.submit.stub.link` at one point?)
- Opening the reset link when logged in (#68) directs you to your user home page.
- Using a reset link **does not invalidate the link**. I *was* thinking this'd be profiled under redflags, but since I'm not sure I even intend to *keep* redflags (probably just rolling it into caveats where it busts the schema and deriving it from profiles otherwise), I've introduced the `expire: unchanged` value.
- Password reset *requires you to enter your email address*, which is weird. Apparently. I'll need to add `password.reset.flow.submit.reauth` as a field.