### PR TITLE
Update coinbase.com.yaml

### DIFF
--- a/profiles/coinbase.com.yaml
+++ b/profiles/coinbase.com.yaml
@@ -69,5 +69,8 @@ login:
       characters: hidden
     persist:
       checkbox: unchecked
+sessions:
+  management:
+    url: https://www.coinbase.com/settings/security_settings#active_sessions
 reviewed:
   date: 2017-02-10T15:03:31.561Z

--- a/profiles/coinbase.com.yaml
+++ b/profiles/coinbase.com.yaml
@@ -1,5 +1,12 @@
 name: Coinbase
 password:
+  value:
+    length:
+      min: 8
+    notes:
+    - en: >
+        Passwords must be rated "good" and not "too weak" by
+        an opaque judgment algorithm.
   reset:
     url: https://coinbase.com/password_resets/new
     flow:
@@ -24,7 +31,17 @@ password:
           own: login
         expire: now
   change:
-    url: https://coinbase.com/account#change_password_modal
+    url: https://coinbase.com/settings#change_password_modal
+    form:
+      oldpassword:
+        input: required
+        characters: hidden
+      newpassword:
+        characters: hidden
+      repeat:
+        newpassword:
+          input: required
+          characters: hidden
 registration:
   url: https://www.coinbase.com/signup
   form:

--- a/profiles/coinbase.com.yaml
+++ b/profiles/coinbase.com.yaml
@@ -7,5 +7,50 @@ password:
         form:
           account:
             accepts: email
+      response:
+        email:
+          sender: no-reply@coinbase.com
+          body: link
+      change:
+        form:
+          newpassword:
+            characters: hidden
+          repeat:
+            newpassword:
+              input: required
+              characters: hidden
+      submit:
+        sessions:
+          own: login
+        expire: now
   change:
     url: https://coinbase.com/account#change_password_modal
+registration:
+  url: https://www.coinbase.com/signup
+  form:
+    firstname:
+      input: required
+    lastname:
+      input: required
+    email:
+      input: required
+      characters: visible
+    password:
+      input: required
+      characters: hidden
+    repeat:
+      email:
+        input: none
+      password:
+        input: none
+login:
+  url: https://www.coinbase.com/signin
+  form:
+    account:
+      accepts: email
+    password:
+      characters: hidden
+    persist:
+      checkbox: unchecked
+reviewed:
+  date: 2017-02-10T15:03:31.561Z


### PR DESCRIPTION
Not profiled:

- Submitting a password reset requests directs to the login page with a modal acknowledgement that I think goes away on a timer.
- Registration requires US state or state-like jurisdiction (ie. military).
- Password needs to be gauged as "good" via some remote arbiter at the endpoint https://api.coinbase.com/v2/users/score-password with the password posted as `password` in a form data body. Needless to say, the rules for passwords to meet this strength requirement are not surfaced. I'm starting to think I need a profile field to document this crap consistently beyond notes. Maybe `password.rule` as a human-text field? (Would still cooperate with data like `password.value.length.max`.)
- Passwords consisting entirely of spaces are rated as "good" past a certain length, but trigger "password can't be blank" errors.
  - Actually, no, they aren't rated as "good"... passwords of only spaces *crash the server*! The API returns a 500 status code in response, and now I'm not seeing any *new* requests going out.
- Logging in and changing password both require a code from Authy.
- Logging in from a new machine requires opening a confirmation link.
- Not profiling destination after resetting a password because it's subject to so much subjectivity re: Authy, new machine approval step...

I just realized I didn't actually review password changing, brb.