### PR TITLE
Remove support.cloud9ide.com.yaml

### DIFF
--- a/profiles/support.cloud9ide.com.yaml
+++ b/profiles/support.cloud9ide.com.yaml
@@ -1,9 +1,0 @@
-name: Cloud9 IDE Support
-password:
-  reset:
-    flow:
-      request:
-        url: http://support.cloud9ide.com/access/help
-        form:
-          email:
-            input: required


### PR DESCRIPTION
As I recall, this was a ZenDesk portal that is no longer up. It could be argued that community.c9.io serves much the same purpose today, but that's a Discourse installation with no continuity in its account system, so it would be profiled separately nonetheless.